### PR TITLE
Using make variable of env, to fix the building problem on FreeBSD

### DIFF
--- a/lib/libpg_query/dune
+++ b/lib/libpg_query/dune
@@ -1,4 +1,4 @@
 (rule
 (deps (source_tree .))
 (targets libpg_query.a)
-(action (run make build)))
+(action (run %{make} build)))


### PR DESCRIPTION
Dear author
I'm an OCaml user who uses FreeBSD.
When I tried to install this library from `opam`,  I found there is an error.
So I submit this patch, try to solve this problem.

Thanks & Regards.
