### PR TITLE
libpg_query: allow overriding `ar`

### DIFF
--- a/lib/libpg_query/Makefile
+++ b/lib/libpg_query/Makefile
@@ -30,7 +30,7 @@ CLEANLIBS = $(ARLIB)
 CLEANOBJS = $(OBJ_FILES)
 CLEANFILES = $(PGDIRBZ2)
 
-AR = ar rs
+AR := $(or $(AR),ar) rs
 RM = rm -f
 ECHO = echo
 


### PR DESCRIPTION
When compiling statically, e.g. using musl, `ar` is actually called e.g. `x86_64-unknown-linux-musl-ar`.

Looking for `$(AR)` in the env allows this library to be compiled statically.