### PR TITLE
Replace ppx_inline_test with alcotest

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -8,7 +8,6 @@
 (library
  (name pg_query)
  (public_name pg_query)
- (inline_tests)
  (modes native)
  (libraries ctypes ctypes.foreign)
  (preprocess

--- a/lib/dune
+++ b/lib/dune
@@ -1,14 +1,16 @@
 (rule
-(deps (source_tree libpg_query))
-(targets libpg_query.a)
-(action (copy libpg_query/libpg_query.a libpg_query.a)))
+ (deps
+  (source_tree libpg_query))
+ (targets libpg_query.a)
+ (action
+  (copy libpg_query/libpg_query.a libpg_query.a)))
 
 (library
-(name pg_query)
-(public_name pg_query)
-(inline_tests)
-(modes native)
-(libraries ctypes ctypes.foreign)
-(preprocess (pps ppx_deriving.show ppx_inline_test))
-(foreign_archives pg_query)
-)
+ (name pg_query)
+ (public_name pg_query)
+ (inline_tests)
+ (modes native)
+ (libraries ctypes ctypes.foreign)
+ (preprocess
+  (pps ppx_deriving.show))
+ (foreign_archives pg_query))

--- a/lib/pg_query.ml
+++ b/lib/pg_query.ml
@@ -42,17 +42,3 @@ let parse query =
   match result.error with
   | None -> Ok result.parse_tree
   | Some { message; _ } -> Error message
-
-let%test _ = (raw_parse "SELECT * FROM users WHERE id = 1").error = None
-
-let%test _ = (raw_parse "SELECT * FROM users WHHERE id = 1").error <> None
-
-let%test _ =
-  match parse "INSERT INTO users (name, email) VALUES (?, ?) RETURNING id" with
-  | Ok _ -> true
-  | Error _ -> false
-
-let%test _ =
-  match parse "INSERT INTO users (name, email) VALUES ?, ? RETURNING id" with
-  | Error _ -> true
-  | Ok _ -> false

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,11 @@
+(executable
+ (name test)
+ (libraries pg_query alcotest)
+ (modules test))
+
+(rule
+ (alias runtest)
+ (package pg_query)
+ (deps test.exe)
+ (action
+  (run %{deps})))

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,0 +1,44 @@
+module Parse_raw = struct
+  let success () =
+    Alcotest.(check @@ bool) "raw_parse success" true (
+      (Pg_query.raw_parse "SELECT * FROM users WHERE id = 1").error = None
+    )
+
+  let error () =
+    Alcotest.(check @@ bool) "raw_parse success" true (
+      (Pg_query.raw_parse "SELECT * FROM users WHHERE id = 1").error <> None
+    )
+end
+
+module Parse = struct
+  let success () =
+    Alcotest.(check @@ bool) "raw_parse success" true (
+      match Pg_query.parse "INSERT INTO users (name, email) VALUES (?, ?) RETURNING id" with
+      | Ok _ -> true
+      | Error _ -> false
+    )
+
+  let error () =
+    Alcotest.(check @@ bool) "raw_parse success" true (
+      match Pg_query.parse "INSERT INTO users (name, email) VALUES ?, ? RETURNING id" with
+      | Error _ -> true
+      | Ok _ -> false
+    )
+end
+
+let () = Alcotest.run "pg_query" [
+  (
+    "parse_raw", 
+    [
+      ("returns no error on correct query", `Quick, Parse_raw.success);
+      ("returns an error on incorrect query", `Quick, Parse_raw.error);
+    ]
+  );
+  (
+    "parse", 
+    [
+      ("returns no error on correct query", `Quick, Parse.success);
+      ("returns an error on incorrect query", `Quick, Parse.error);
+    ]
+  );
+]


### PR DESCRIPTION
`ppx_inline_test` still relies on core which was removed in #4. 
Right now this results in a build error because `ppx_inline_test` can't be found.

This PR replaces the tests defined with `ppx_inline_test` with `alcotest`.