### PR TITLE
Add strchrnul fix for FreeBSD 13

### DIFF
--- a/lib/libpg_query/src/postgres/include/pg_config.h
+++ b/lib/libpg_query/src/postgres/include/pg_config.h
@@ -503,6 +503,9 @@
 
 /* Define to 1 if you have the `strchrnul' function. */
 /* #undef HAVE_STRCHRNUL */
+#ifdef __FreeBSD__
+#define HAVE_STRCHRNUL 1
+#endif
 
 /* Define to 1 if you have the `strerror_r' function. */
 #define HAVE_STRERROR_R 1

--- a/lib/libpg_query/src/postgres/src_port_snprintf.c
+++ b/lib/libpg_query/src/postgres/src_port_snprintf.c
@@ -368,6 +368,7 @@ static void trailing_pad(int padlen, PrintfTarget *target);
  * Note: glibc declares this as returning "char *", but that would require
  * casting away const internally, so we don't follow that detail.
  */
+
 #ifndef HAVE_STRCHRNUL
 
 static inline const char *


### PR DESCRIPTION
Something broke FreeBSD compilation in FreeBSD 13, #10 has the error message. 