### PR TITLE
fix(x-compilation): portable `ar`

### DIFF
--- a/lib/libpg_query/Makefile
+++ b/lib/libpg_query/Makefile
@@ -62,7 +62,9 @@ CLEANLIBS = $(ARLIB)
 CLEANOBJS = $(OBJ_FILES)
 CLEANFILES = $(PGDIRBZ2)
 
-AR = ar rs
+AR ?= ar
+AR := $(AR) rs
+
 INSTALL = install
 LN_S = ln -s
 RM = rm -f


### PR DESCRIPTION
In cross-compilation scenarios, `CC` and `AR` will have a prefix like `x86_64-unknown-linux-musl-`.

In those cases, `$AR` will be set to the correct program, which we should use.