### PR TITLE
fix: builds on glibc >= 2.38

### DIFF
--- a/lib/libpg_query/Makefile
+++ b/lib/libpg_query/Makefile
@@ -155,7 +155,8 @@ extract_source: $(PGDIR)
 	# Avoid dependency on cpuid.h (only supported on x86 systems)
 	echo "#undef HAVE__GET_CPUID" >> ./src/postgres/include/pg_config.h
 	# Ensure we don't fail on systems that have strchrnul support (FreeBSD)
-	echo "#ifdef __FreeBSD__" >> ./src/postgres/include/pg_config.h
+	echo "#include <stdlib.h>" >>  $(PGDIR)/src/include/pg_config.h
+	echo "#if defined(__FreeBSD__) || defined(__NetBSD__) || (defined(__GLIBC__) && ((__GLIBC__ == 2 && __GLIBC_MINOR__ >= 38) || __GLIBC__ > 2))" >> $(PGDIR)/src/include/pg_config.h
 	echo "#define HAVE_STRCHRNUL" >> ./src/postgres/include/pg_config.h
 	echo "#endif" >> ./src/postgres/include/pg_config.h
 	# Copy version information so its easily accessible

--- a/lib/libpg_query/src/postgres/include/pg_config.h
+++ b/lib/libpg_query/src/postgres/include/pg_config.h
@@ -990,6 +990,7 @@
 #undef HAVE_EXECINFO_H
 #undef HAVE_BACKTRACE_SYMBOLS
 #undef HAVE__GET_CPUID
-#ifdef __FreeBSD__
+#include <stdlib.h>
+#if defined(__FreeBSD__) || defined(__NetBSD__) || (defined(__GLIBC__) && ((__GLIBC__ == 2 && __GLIBC_MINOR__ >= 38) || __GLIBC__ > 2))
 #define HAVE_STRCHRNUL
 #endif


### PR DESCRIPTION

fixes #16

upgrading libpg_query is a bit too painful this time since they removed support for parsing `?` param refs, which e.g. ppx_rapper depends on. 

This change simply ports https://github.com/pganalyze/libpg_query/commit/9b21e3295402a0d0ee9a50c468d426c2dbb73ee6 over from upstream.